### PR TITLE
Adds support for basic pipeline loader and many parsing improvements

### DIFF
--- a/src/JapeLexer.g4
+++ b/src/JapeLexer.g4
@@ -11,6 +11,8 @@ LINE_COMMENT
 	: '//' ~[\r\n]* -> skip
 	;
 
+IMPORTS: 'Imports' -> pushMode(JAVA), skip;
+// IMPORTS2: IMPORTS ALIAS_SEPARATOR RULE_ENTRY_OPEN -> pushMode(JAVA);
 
 INPUT: 'Input';
 PHASE: 'Phase';
@@ -67,3 +69,21 @@ COMPARE
     | '!=~'
     ;
 
+OTHER: . -> skip;
+
+mode JAVA;
+
+OPEN: '{' -> mode(JAVA_BLOCK), skip;
+OTHER_JAVA: . -> skip;
+
+mode JAVA_BLOCK;
+
+fragment BLOCK_CONTENT: ~[{}]+;
+
+
+CONTENT
+    : BLOCK_CONTENT -> skip;
+
+CONTENT_BLOCK: '{' (BLOCK_CONTENT|CONTENT_BLOCK) '}' -> skip;
+
+CLOSE: '}' -> popMode, skip;

--- a/src/JapeLexer.g4
+++ b/src/JapeLexer.g4
@@ -47,6 +47,8 @@ ENTRIES_SEPARATOR: ',';
 RULE_SEPARATOR: '|';
 GROUP_OPEN: '(';
 GROUP_CLOSE: ')';
+RANGE_OPEN: '[';
+RANGE_CLOSE: ']';
 ALIAS_SEPARATOR: ':';
 RULE_ENTRY_OPEN: '{' {
     if (this._javaImports) {
@@ -76,7 +78,7 @@ COMPARE
 
 RHS_SEPARATOR: '-->' { this._rhsMode = true; };
 
-OTHER: . -> skip;
+// OTHER: . -> skip;
 
 mode JAVA_BLOCK;
 

--- a/src/JapeLexer.g4
+++ b/src/JapeLexer.g4
@@ -24,6 +24,13 @@ TEMPLATE: 'Template';
 
 INT: [1-9] [0-9]*;
 
+CONTEXT_OPERATORS
+    : 'contains'
+    | 'notContains'
+    | 'within'
+    | 'notWithin'
+    ;
+
 IDENTIFIER
     : [a-zA-Z] [a-zA-Z0-9_]* 
     | '"' IDENTIFIER '"'
@@ -60,4 +67,3 @@ COMPARE
     | '!=~'
     ;
 
-// TODO: add contains, notContains, within, notWithin operators

--- a/src/JapeParser.g4
+++ b/src/JapeParser.g4
@@ -68,14 +68,19 @@ rulePriority
     ;
 
 ruleBlock
-    : GROUP_OPEN ruleBlockContent GROUP_CLOSE RULE_KLEENE_OPERATOR? (ALIAS_SEPARATOR IDENTIFIER)?
+    : GROUP_OPEN ruleBlockContent GROUP_CLOSE ruleBlockContentQuantifier? (ALIAS_SEPARATOR IDENTIFIER)?
     ;
 
 ruleBlockContent
     : ruleBlockContent RULE_SEPARATOR? ruleBlockContent
-    | GROUP_OPEN ruleBlockContent GROUP_CLOSE RULE_KLEENE_OPERATOR? (ALIAS_SEPARATOR IDENTIFIER)?
+    | GROUP_OPEN ruleBlockContent GROUP_CLOSE ruleBlockContentQuantifier? (ALIAS_SEPARATOR IDENTIFIER)?
     | ruleEntry
     | IDENTIFIER
+    ;
+
+ruleBlockContentQuantifier
+    : RULE_KLEENE_OPERATOR
+    | RANGE_OPEN INT (ENTRIES_SEPARATOR INT)? RANGE_CLOSE
     ;
 
 ruleEntry

--- a/src/JapeParser.g4
+++ b/src/JapeParser.g4
@@ -79,7 +79,9 @@ ruleEntry
     ;
 
 ruleClause
-    : IDENTIFIER (ACCESSOR IDENTIFIER)? (COMPARE value)?
+    : IDENTIFIER
+    | IDENTIFIER CONTEXT_OPERATORS IDENTIFIER
+    | IDENTIFIER (ACCESSOR|VIRTUAL_ACCESSOR) IDENTIFIER COMPARE value 
     ;
 
 // -------------------- RHS --------------------------

--- a/src/JapeParser.g4
+++ b/src/JapeParser.g4
@@ -25,11 +25,15 @@ phasesDecl:
 // -------------- single phase -------------------
 
 singlePhase:
+    importsDecl?
     phaseDecl
     (inputDecl)*
     optionsDecl?
     (ruleDecl|macroDecl)*
     ;
+
+importsDecl:
+    IMPORTS ALIAS_SEPARATOR RULE_ENTRY_OPEN JAVA_CODE RULE_ENTRY_CLOSE;
 
 inputDecl:
     INPUT ALIAS_SEPARATOR IDENTIFIER+;
@@ -92,7 +96,7 @@ rhs
 
 rhsEntry
     : japeRhs
-    | (ALIAS_SEPARATOR IDENTIFIER)? RULE_ENTRY_OPEN .*? RULE_ENTRY_CLOSE
+    | (ALIAS_SEPARATOR IDENTIFIER)? RULE_ENTRY_OPEN JAVA_CODE RULE_ENTRY_CLOSE
     ;
 
 japeRhs

--- a/src/JapeParser.g4
+++ b/src/JapeParser.g4
@@ -92,6 +92,7 @@ rhs
 
 rhsEntry
     : japeRhs
+    | (ALIAS_SEPARATOR IDENTIFIER)? RULE_ENTRY_OPEN .*? RULE_ENTRY_CLOSE
     ;
 
 japeRhs

--- a/src/JapeParserVisitor.ts
+++ b/src/JapeParserVisitor.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: salterok 
  * @Date: 2018-02-19 23:27:35 
- * @Last Modified by: mikey.zhaopeng
- * @Last Modified time: 2018-07-16 23:42:31
+ * @Last Modified by: Sergiy Samborskiy
+ * @Last Modified time: 2018-07-17 17:16:38
  */
 
 import { JapeParserVisitor as IJapeParserVisitor } from "./parser/JapeParserVisitor";
@@ -20,7 +20,7 @@ export class JapeParserVisitor extends AbstractParseTreeVisitor<D.Phase> impleme
         return { __default: true } as any;
     }
 
-    visitProgram(ctx: P.ProgramContext): D.Phase | D.MultiPhase {
+    visitProgram(ctx: P.ProgramContext): D.SinglePhase | D.MultiPhase {
         const single = ctx.singlePhase();
 
         if (single) {
@@ -50,8 +50,8 @@ export class JapeParserVisitor extends AbstractParseTreeVisitor<D.Phase> impleme
         return ctx.IDENTIFIER().map(node => node.text);
     }
 
-    visitSinglePhase(ctx: P.SinglePhaseContext): D.Phase {
-        const phase = new D.Phase();
+    visitSinglePhase(ctx: P.SinglePhaseContext): D.SinglePhase {
+        const phase = new D.SinglePhase();
 
         phase.name = this.visitPhaseDecl(ctx.phaseDecl());
 

--- a/src/JapeSyntaxDefinitions.ts
+++ b/src/JapeSyntaxDefinitions.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: mikey.zhaopeng 
  * @Date: 2018-04-01 23:50:26 
- * @Last Modified by: mikey.zhaopeng
- * @Last Modified time: 2018-07-16 23:37:23
+ * @Last Modified by: Sergiy Samborskiy
+ * @Last Modified time: 2018-07-17 14:51:32
  */
 
 interface SourceBlock {
@@ -13,9 +13,11 @@ interface SourceBlock {
 export class MultiPhase {
     name!: string;
     phaseNames!: string[];
+
+    phases!: Map<string, Phase>;
 }
 
-export class Phase {
+export class SinglePhase {
     name!: string;
     inputs!: string[];
     options!: PhaseOptions;
@@ -24,6 +26,8 @@ export class Phase {
     rules!: Rule[];
     // macros: Macro[];
 }
+
+export type Phase = SinglePhase | MultiPhase;
 
 export class PhaseOptions extends Map<string, string> {
     

--- a/src/TransducerPipeline.ts
+++ b/src/TransducerPipeline.ts
@@ -1,0 +1,39 @@
+/*
+* @Author: Sergiy Samborskiy 
+* @Date: 2018-07-17 13:02:36 
+ * @Last Modified by: Sergiy Samborskiy
+ * @Last Modified time: 2018-07-17 19:11:17
+*/
+
+import { JapeContext } from "./JapeContext";
+import * as path from "path";
+import { Phase, MultiPhase } from "./JapeSyntaxDefinitions";
+
+export class TransducerPipeline {
+    private japeCtx: JapeContext;
+    public filename: string;
+    public phase: MultiPhase;
+    
+    constructor(filename: string, phase: MultiPhase, japeCtx: JapeContext) {
+        this.filename = filename;
+        this.phase = phase;
+        this.japeCtx = japeCtx;
+    }
+
+    addPhase(filename: string, phase: Phase): boolean {
+        const name = path.relative(this.filename, filename);
+        if (!this.phase.phaseNames.includes(name)) {
+            return false;
+        }
+
+        if (!this.phase.phases.has(name)) {
+            this.phase.phases.set(name, phase);
+        }
+        return true;
+    }
+}
+
+export interface FileLoader {
+    load(path: string): Promise<{ version: number; text: string } | null>;
+    allFiles(glob: string): Promise<string[]>;
+}

--- a/src/VsCodeContext.ts
+++ b/src/VsCodeContext.ts
@@ -1,0 +1,26 @@
+/*
+ * @Author: Sergiy Samborskiy 
+ * @Date: 2018-07-17 14:15:40 
+ * @Last Modified by: Sergiy Samborskiy
+ * @Last Modified time: 2018-07-17 18:11:18
+ */
+
+import { JapeContext } from "./JapeContext";
+import * as vscode from "vscode";
+
+
+export const japeCtx = new JapeContext({
+    async allFiles(glob: string): Promise<string[]> {
+        const files = await vscode.workspace.findFiles(glob);
+        
+        return files.map(file => file.fsPath);
+    },
+    async load(file: string): Promise<{ version: number; text: string; } | null> {
+        const doc = await vscode.workspace.openTextDocument(file);
+
+        if (!doc) {
+            return null;
+        }
+        return { text: doc.getText(), version: doc.version };
+    }
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,19 @@
 /*
  * @Author: salterok 
  * @Date: 2018-02-15 23:21:27 
- * @Last Modified by: mikey.zhaopeng
- * @Last Modified time: 2018-07-16 22:54:28
+ * @Last Modified by: Sergiy Samborskiy
+ * @Last Modified time: 2018-07-17 18:03:48
  */
 
 import * as vscode from "vscode";
 
 import { CompletionItemKind } from "vscode";
 
-import japeCtx, { JapeContext } from "./JapeContext";
+import { JapeContext } from "./JapeContext";
 import { JapeLexer } from "./parser/JapeLexer";
 import { Place } from "./utils";
+
+import { japeCtx } from "./VsCodeContext";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -40,11 +42,14 @@ export function activate(context: vscode.ExtensionContext) {
         ),
     );
 
+    const activeTextEditor = vscode.window.activeTextEditor;
+    if (activeTextEditor) {
+        japeCtx.loadPipelines(activeTextEditor.document.fileName).catch(console.error);
+    }
+
     vscode.workspace.onDidChangeTextDocument(e => {
         // console.log("Edit", e.document.fileName, e.contentChanges);
-        console.time("Parse: " + e.document.fileName);
         japeCtx.loadFromSource(e.document.fileName, e.document.getText());
-        console.timeEnd("Parse: " + e.document.fileName);
     });
     vscode.workspace.onDidOpenTextDocument(e => {
         if (e.fileName.endsWith(".jape")) {

--- a/syntaxes/jape.tmLanguage.json
+++ b/syntaxes/jape.tmLanguage.json
@@ -79,6 +79,9 @@
 					"end": "}",
 					"patterns": [
 						{
+							"include": "#context-operators"
+						},
+						{
 							"include": "#entity-access"
 						},
 						{
@@ -270,7 +273,16 @@
 			"patterns": [
 				{
 					"name": "keyword.operator",
-					"match": "<|>|[!=]=?[=~]|[=><!]=|contains|notContains|within|notWithin"
+					"match": "<|>|[!=]=?[=~]|[=><!]="
+				}
+			]
+		},
+
+		"context-operators": {
+			"patterns": [
+				{
+					"name": "keyword",
+					"match": "contains|notContains|within|notWithin"
 				}
 			]
 		},

--- a/syntaxes/jape.tmLanguage.json
+++ b/syntaxes/jape.tmLanguage.json
@@ -50,7 +50,7 @@
 				{
 					"name": "entity.name.section",
 					"begin": "\\(",
-					"end": "\\)\\s?\\??(\\s?:\\s?([a-zA-Z_][a-zA-Z_\\d]*))?",
+					"end": "\\)\\s?(?:[\\?\\+\\*]|\\[\\s*\\d(?:\\s*,\\s*\\d)*\\s*\\])?(\\s?:\\s?([a-zA-Z_][a-zA-Z_\\d]*))?",
 					"endCaptures": {
 						"2": {
 							"name": "keyword.control.jape"

--- a/syntaxes/jape.tmLanguage.json
+++ b/syntaxes/jape.tmLanguage.json
@@ -176,6 +176,21 @@
 		"keywords": {
 			"patterns": [
 				{
+					"contentName": "source.java",
+					"begin": "\\b(Imports)\\s*:\\s*\\{",
+					"end": "\\}",
+					"patterns": [
+						{
+							"name": "source.java"
+						}
+					],
+					"beginCaptures": {
+						"1": {
+							"name": "keyword"
+						}
+					}
+				},
+				{
 					"match": "\\b(Phase)\\s*:\\s*([a-zA-Z_][a-zA-Z_\\d]*)",
 					"captures": {
 						"1": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2017",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es2016"
         ],
         "sourceMap": true,
         "rootDir": "src",


### PR DESCRIPTION
Added support to parse jape files in workspace and building those files in pipelines.
Huge performance increase in parsing jape with java code blocks.
Adds parser support for kleene operators and range notation.